### PR TITLE
Sub-Sub-Domain detection for Container Name

### DIFF
--- a/src/create-link/entrypoint.sh
+++ b/src/create-link/entrypoint.sh
@@ -12,7 +12,7 @@ export WG_PRIVKEY=$(wg genkey)
 # NOTE: All traffic for `*.subdomain.domain.tld`` will be routed to the container named `subdomain-domain-tld``
 # Also supports `subdomain.domain.tld` as well as apex `domain.tld`
 # *.domain.tld should resolve to the Gateway's public IPv4 address
-export CONTAINER_NAME=$(echo $LINK_DOMAIN|python3 -c 'fqdn=input();print("-".join(fqdn.split(".")[-3:]))')
+export CONTAINER_NAME=$(echo $LINK_DOMAIN|python3 -c 'fqdn=input();print("-".join(fqdn.split(".")))')
 
 
 LINK_CLIENT_WG_PUBKEY=$(echo $WG_PRIVKEY|wg pubkey)


### PR DESCRIPTION
"Fixed" issue that presents itself with sub-subdomains.

If a domain has more than 2 sub-domains, this would name all the containers the same, causing a Container naming conflict in docker.

Originally, 
subdomain.domain.tld -> subdomain-domain-tld
sub-subdomain.subdomain-domain-tld -> subdomain-domain-tld This version:
subdomain.domain.tld -> subdomain-domain-tld
sub-subdomain.subdomain-domain-tld -> sub-subdomain-subdomain-domain-tld

This should fix duplicate container issues for duckdns users, who's domain generally will look like: subdomain.domain.duckdns.org