### PR TITLE
Update nginx.conf.template for app compatibility

### DIFF
--- a/src/gateway/nginx.conf.template
+++ b/src/gateway/nginx.conf.template
@@ -31,7 +31,7 @@ events {
 
     stream {  
         map $ssl_preread_server_name $targetBackend {
-            ~^(?<app>.+?)?\.(?<subdomain>.+?)?\.(?<domain>.+)\.(?<tld>.+)$ $subdomain-$domain-$tld:443;
+            ~^(?<app>.+?)?\.(?<subdomain>.+?)?\.(?<domain>.+)\.(?<tld>.+)$ $app-$subdomain-$domain-$tld:443;
             ~^(?<subdomain>.+?)?\.(?<domain>.+)\.(?<tld>.+)$ $subdomain-$domain-$tld:443;
             ~^(?<domain>.+)\.(?<tld>.+)$ $domain-$tld:443;
         } 


### PR DESCRIPTION
Makes use of the app detection in the NGINX mapping.

Previously, if a sub-subdomain of a domain was used, nginx would fail to properly parse the url.

With the change to allow sub-subdomains in 
    selfhosted-gateway/gateway/scripts/create-link.sh

You can now have a docker container with the name: subdomain.domain.duckdns.org -> subdomain-domain-duckdns-org

NGINX will not properly grab the subdomain section of this, because it previously would only grab domain-duckdns-org, when it needs to grab subdomain-domain-duckdns-org.